### PR TITLE
add inbox permission

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,11 +62,18 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    
     api.url = "/api"
     api.allowed = "visitors"
     api.auth_header = false
     api.show_tile = false
     api.protected = true
+
+    inbox.url = "/inbox"
+    inbox.allowed = "visitors"
+    inbox.auth_header = false
+    inbox.show_tile = false
+    inbox.protected = true
 
     [resources.apt]
     packages = "postgresql espeak"


### PR DESCRIPTION
## Problem

Previously added the API permission, but realized that other instances don't federate using the `/api` endpoint, they `post` to the `/inbox` endpoint.

## Solution

This adds another permission for the `/inbox` endpoint to remain public so that the installed instance can remain private (being Yunohost login) but still take part in the fediverse and receive content from other instances.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
